### PR TITLE
ci: add weekly Monday Snyk scan schedule

### DIFF
--- a/snyk-scan.yml
+++ b/snyk-scan.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  schedule:
+    # Weekly on Monday 06:00 UTC (GitHub Actions cron is UTC-only)
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds `schedule` (Mondays 06:00 UTC) to root `snyk-scan.yml` so the example/calling workflow runs weekly via the org reusable workflow.